### PR TITLE
Update trade card, so it's more balanced

### DIFF
--- a/src/card.dd
+++ b/src/card.dd
@@ -63,9 +63,11 @@
 		(= this.cardDescription "move the rose 3 steps")
 	(== this.id 2)
 		(= this.cardDescription (multistring
-			"The rose player grabs the rose then"
+			"The rose player grabs the rose then "
 			"give a card to the rose player and "
-			"receive a random card back then "
+			"receive a random card back   "
+			"if the rose was picked receive an "
+			"additional card   "
 			"move the rose 1 step "
 			)
 		)

--- a/src/game.dd
+++ b/src/game.dd
@@ -694,7 +694,7 @@
 				)
 			# AI has to select a card or user selects randomly
 				(group
-				(= this.lastSelectedCardPlayerIndex this.actions[0].playerIndex)
+				(= this.lastSelectedCardPlayerIndex this.actions[0].value)
 				(= this.lastSelectedCardIndex (dd_math_rand this.player[this.lastSelectedCardPlayerIndex].cardsTotal))
 				(= this.actions[0].actionType ACTION_DELAY)
 				#(this.player[this.actions[0].playerIndex].selectCard)
@@ -796,9 +796,18 @@
 				(== cardId CARD_TRADE)
 					(group
 
+					# the active player is the flirt - make the rose flat,
+					# the rest of the effect is skipped
 					(if (== this.rosePlayer this.actions[0].playerIndex)
 						(group
+						(if (== this.isRoseFlat 0)
+							(group
+							(this.addInjectAction ACTION_ADVANCE_ROSE 0 1 50)
+							(this.injectActionsToActions)
+							)
 						)
+						)
+					# the active player is NOT the flirt - continue with effect
 						(group
 
 						# rose player picks up rose
@@ -812,7 +821,14 @@
 
 						# rose player selects and gives a card to active player
 						# TODO: should be given a card at random, rose player doesn't select
-						(this.addInjectAction ACTION_SELECT_CARD this.rosePlayer this.rosePlayer 0)
+						(this.addInjectAction ACTION_SELECT_CARD this.actions[0].playerIndex this.rosePlayer 0)
+
+						# if rose was selected, take an additional card
+						(this.addInjectAction ACTION_IF_SELECTED_CARD_EQUALS 0 CARD_ROSE 0)
+						(this.addInjectAction ACTION_GIVE_CARD this.actions[0].playerIndex 0 50)
+						(this.addInjectAction ACTION_SELECT_CARD this.actions[0].playerIndex this.rosePlayer 0)
+						(this.addInjectAction ACTION_ENDIF 0 0 0)
+
 						(this.addInjectAction ACTION_GIVE_CARD this.actions[0].playerIndex 0 50)
 
 						# move rose one step


### PR DESCRIPTION
There was an issue with the trade card, where if the active player picked the Rose, they would end up with one less card in their hand. This was not intended, so the effect was updated.

Now if a player gets the Rose using the trade card, they receive an additional card.