### PR TITLE
Update conditional card to trigger based on the previous player being the flirt

### DIFF
--- a/src/card.dd
+++ b/src/card.dd
@@ -71,10 +71,10 @@
 		)
 	(== this.id 3)
 		(= this.cardDescription (multistring
-			"if the rose is 1 step before you "
-			"move it 1 step "
+			"if the previous player is the flirt "
+			"move the Rose 1 step "
 			"otherwise "
-			"move it 3 steps"
+			"move the Rose 3 steps"
 			)
 		)
 	(== this.id 4)

--- a/src/game.dd
+++ b/src/game.dd
@@ -824,7 +824,7 @@
 					)
 
 					)
-				# If rose is one step before active user, move it one step, otherwise move it three steps
+				# if previous player is the flirt, move Rose one step, otherwise three steps
 				(== cardId CARD_CONDITIONAL)
 					(group
 					(def int onePreviousIndex (% (- (+ this.actions[0].playerIndex this.playersTotal) 1) this.playersTotal))


### PR DESCRIPTION
The card was working this way until now, but it was originally intended to check if the Rose was "One step" before the active player.

Because this turned out to increase the complexity of the game, I decided to simplify it by checking if the previous player is the flirt or not.