### PR TITLE
Initialise rotating indicator's rotation, to avoid visual issues

### DIFF
--- a/src/game.dd
+++ b/src/game.dd
@@ -445,6 +445,9 @@
 	(= this.arrowCurrentCol[1] 0.0)
 	(= this.arrowCurrentCol[2] 0.0)
 
+	(= this.arrowRotation 0)
+	(= this.arrowRotationTarget 0)
+
 	)
 )
 


### PR DESCRIPTION
The rotating indicator had a tiny bug that its rotation wasn't initialised, so its value was undefined when the game started. This means that sometimes when the game starts, its rotation would be a very big or very small number, causing the indicator to spin around the table multiple times before it reaches the active player.

This wasn't impacting the game in any way, except visually.